### PR TITLE
do not build_ext --inplace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 install:
 	pip install -U pip wheel setuptools
 	pip install -r requirements.txt
+	python setup.py build_ext
 	pip install -e .
 
 .PHONY: lint

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ About this project...
 
 ## Installation
 
-Installation instructions...
+```
+$ make install
+```
 
 ## Usage
 
@@ -15,4 +17,6 @@ Usage instructions...
 
 ## Test
 
-Testing instructions...
+```
+$ make test
+```

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
 from setuptools import setup, find_packages
-# from setuptools import Extension
+from setuptools import Extension
+
 
 try:
     from Cython.Distutils import build_ext
@@ -10,13 +11,15 @@ except ImportError:
 else:
     use_cython = True
 
+
 readme = Path(__file__).parent.joinpath('README.md')
 if readme.exists():
     with readme.open() as f:
         long_description = f.read()
         try:
             from pypandoc import convert_text
-            long_description = convert_text(long_description, 'rst', format='md')
+            long_description = convert_text(
+                long_description, 'rst', format='md')
         except ImportError:
             print("warning: pypandoc module not found, could not convert Markdown to RST")
 else:
@@ -27,12 +30,19 @@ ext_modules = []
 
 if use_cython:
     ext_modules += [
-        # Extension('uttut.elements', ['uttut/elements.pyx']),
+        Extension(
+            'strpipe.toolkit.compute_maxlen',
+            ['strpipe/toolkit/compute_maxlen.pyx'],
+            # language="c++",
+        ),
     ]
     cmdclass.update({'build_ext': build_ext})
 else:
     ext_modules += [
-        # Extension('uttut.elements', ['uttut/elements.c']),
+        Extension(
+            'strpipe.toolkit.compute_maxlen',
+            ['strpipe/toolkit/compute_maxlen.c'],
+        ),
     ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from setuptools import setup, find_packages
-from setuptools import Extension
+# from setuptools import Extension
 
 
 try:
@@ -30,20 +30,14 @@ ext_modules = []
 
 if use_cython:
     ext_modules += [
-        Extension(
-            'strpipe.toolkit.compute_maxlen',
-            ['strpipe/toolkit/compute_maxlen.pyx'],
-            # language="c++",
-        ),
+        # Extension('uttut.elements', ['uttut/elements.pyx']),
     ]
     cmdclass.update({'build_ext': build_ext})
 else:
     ext_modules += [
-        Extension(
-            'strpipe.toolkit.compute_maxlen',
-            ['strpipe/toolkit/compute_maxlen.c'],
-        ),
+        # Extension('uttut.elements', ['uttut/elements.c']),
     ]
+
 
 setup(
     name='strpipe',


### PR DESCRIPTION
QAQ
- Remove the folder `build` and all `.so` before you compile `.pyx`.
- Do Not use `python setup.py build_ext --inplace`
  (This is because you would forget removing `.so` files)
  (If you remove anything and forget the `.so` file, you still can use the compiled functions.)  