### PR TITLE
modify return value of inverse_transform

### DIFF
--- a/strpipe/ops/base.pxd
+++ b/strpipe/ops/base.pxd
@@ -10,4 +10,4 @@ cdef class BaseOp:
     cdef transform(state, input)
 
     @staticmethod
-    cdef inverse_transfrom(state, input, meta)
+    cdef inverse_transfrom(state, input, tx_info)

--- a/strpipe/pipe.py
+++ b/strpipe/pipe.py
@@ -104,7 +104,7 @@ class Pipe:
             meta = tx_info[idx]
             step = self._steps[idx]
             data = step.inverse_transform(data, meta)
-        return data, tx_info
+        return data
 
     def save_json(self, path):
         serializable = {}


### PR DESCRIPTION
For simplicity, `inverse_transform` should return only the transformed data.