### PR TITLE
fix_bug: Fixtures are not meant to be called directly

### DIFF
--- a/strpipe/tests/test_pipe.py
+++ b/strpipe/tests/test_pipe.py
@@ -58,7 +58,7 @@ def fake_factory():
 
 
 @pytest.fixture
-def fake_pipe(fake_factory=fake_factory()):
+def fake_pipe(fake_factory):
     p_custom = Pipe(op_factory=fake_factory)
     p_custom.add_step_by_op_name(
         'StatefulOp',


### PR DESCRIPTION
```
__________ ERROR collecting strpipe/tests/test_pipe.py ______________________________
strpipe/tests/test_pipe.py:61: in <module>
    def fake_pipe(fake_factory=fake_factory()):
E   _pytest.warning_types.RemovedInPytest4Warning: Fixture "fake_factory" called directly. Fixtures are not meant to be called directly, are created automatically when
 test functions request them as parameters. See https://docs.pytest.org/en/latest/fixture.html for more information.
```